### PR TITLE
Fix issue with receiving chunked packets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
                 "--db_port", "2999",
                 "--game_address", "0.0.0.0",
                 "--game_port", "3000",
-                "--processing_threads", "1",
+                "--processing_threads", "12",
                 "--config_path", "/config"
             ],
             "stopAtEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
                 "--db_port", "2999",
                 "--game_address", "0.0.0.0",
                 "--game_port", "3000",
-                "--processing_threads", "12",
+                "--processing_threads", "1",
                 "--config_path", "/config"
             ],
             "stopAtEntry": false,

--- a/apps/gameserver/include/World.h
+++ b/apps/gameserver/include/World.h
@@ -500,6 +500,11 @@ public:
         std::lock_guard<std::recursive_mutex> lock(Get().m_entities_rmtx);
         Map(map_id).For(kind, id, callback);
     }
+
+    static size_t GetTotalPlayerCount()
+    {
+        return Get().m_players.size();
+    }
 };
 
 inline WorldMap::QUERY_KIND operator|(WorldMap::QUERY_KIND a, WorldMap::QUERY_KIND b)

--- a/apps/gameserver/src/main.cpp
+++ b/apps/gameserver/src/main.cpp
@@ -130,7 +130,10 @@ int main(int argc, char** argv)
     CommandDispatcher::Register("/moveto",          std::bind(&Player::OnMoveTo,            _1, _2));
 
     CommandDispatcher::Register("/online", [&](Player& player, CommandDispatcher::Token& token) {
-        std::string message = std::string{"Current Online: "} + std::to_string(Socket::GameServer().get_online());
+        std::stringstream ss;
+        ss  << "Players in world: "     << World::GetTotalPlayerCount() << " / "
+            << "Current connections: "  << Socket::GameServer().get_online();
+        auto message = ss.str();
         player.write(packet(S2C_NOTICE, "s", message.c_str()));
     });
 

--- a/core/network/include/bango/network/client.h
+++ b/core/network/include/bango/network/client.h
@@ -17,6 +17,8 @@ namespace bango { namespace network {
 
         void execute(packet&& p) const;
 
+        // possibly reserve MAX_PACKET_LENGTH for better perf
+        std::vector<char> remaining_buffer;
 
     public:
 

--- a/core/network/src/client.cpp
+++ b/core/network/src/client.cpp
@@ -28,20 +28,22 @@ void client::on_new_message(const taco_read_result_t& res)
             if (remaining_buffer.size() < 3)
                 break;
 
+            auto packet_size = ((unsigned short*)remaining_buffer.data())[0];
+
             // not enough packet buffer data than declared in the packet yet
-            if (((unsigned short*)remaining_buffer.data())[0] > remaining_buffer.size())
+            if (packet_size > remaining_buffer.size())
                 break;
 
-            if (((unsigned short*)remaining_buffer.data())[0] < 3)
+            if (packet_size < 3)
             {
-                std::cerr << "wrong packet size: " << ((unsigned short*)remaining_buffer.data())[0] << "\n";
+                std::cerr << "wrong packet size: " << packet_size << "\n";
                 // TODO: Kick?
                 remaining_buffer.clear();
                 return;
             }
 
-            execute(packet(std::vector<char>(remaining_buffer.begin(), remaining_buffer.begin() + ((unsigned short*)remaining_buffer.data())[0])));
-            remaining_buffer.erase(remaining_buffer.begin(), remaining_buffer.begin() + ((unsigned short*)remaining_buffer.data())[0]);
+            execute(packet(std::vector<char>(remaining_buffer.begin(), remaining_buffer.begin() + packet_size)));
+            remaining_buffer.erase(remaining_buffer.begin(), remaining_buffer.begin() + packet_size);
 
             if (remaining_buffer.size() == 0)
                 break;

--- a/core/network/src/client.cpp
+++ b/core/network/src/client.cpp
@@ -1,7 +1,5 @@
 #include <bango/network/client.h>
 
-#include <cassert>
-
 using namespace bango::network;
 
 void client::connect(const std::string& host, std::int32_t port)


### PR DESCRIPTION
The server handled only packets which content is entirely contained inside one recv buffer. Now it keeps track of remaining unhandled bytes and waits for next chunk to concatenate and handle.